### PR TITLE
Resolve warning (iOS)

### DIFF
--- a/ios/RNPasscodeStatus.m
+++ b/ios/RNPasscodeStatus.m
@@ -40,6 +40,11 @@ RCT_EXPORT_METHOD(get:(RCTResponseSenderBlock)callback)
   return [NSDictionary dictionaryWithDictionary:constants];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 + (NSString *) getPasscodeStatusString:(LNPasscodeStatus) status
 {
   switch (status) {


### PR DESCRIPTION
Module `RNPasscodeStatus` requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.